### PR TITLE
Add missing type specifier

### DIFF
--- a/cmd.lisp
+++ b/cmd.lisp
@@ -20,7 +20,7 @@
 (in-package :cmd)
 
 (deftype absolute-directory-pathname ()
-  `(and (satisfies absolute-pathname-p)
+  '(and (satisfies absolute-pathname-p)
         (satisfies directory-pathname-p)))
 
 (defun current-dir ()

--- a/cmd.lisp
+++ b/cmd.lisp
@@ -19,6 +19,10 @@
     :with-cmd-dir))
 (in-package :cmd)
 
+(deftype absolute-directory-pathname ()
+  `(and (satisfies absolute-pathname-p)
+        (satisfies directory-pathname-p)))
+
 (defun current-dir ()
   (let ((dpd *default-pathname-defaults*))
     (if (typep dpd 'absolute-directory-pathname)


### PR DESCRIPTION
The type specifier `ABSOLUTE-DIRECTORY-PATHNAME` does not appear to be defined in this project, but is used by `CMD:CURRENT-DIRECTORY`. I've written an implementation that uses the UIOP pathname predicates imported at the top of `cmd.lisp`.